### PR TITLE
[Feat/events/list/all] 메인 페이지 캘린더 표시

### DIFF
--- a/.idea/compiler.xml
+++ b/.idea/compiler.xml
@@ -6,6 +6,16 @@
         <outputRelativeToContentRoot value="true" />
         <processorPath useClasspath="false">
           <entry name="$USER_HOME$/.gradle/caches/modules-2/files-2.1/org.projectlombok/lombok/1.18.36/5a30490a6e14977d97d9c73c924c1f1b5311ea95/lombok-1.18.36.jar" />
+          <entry name="$USER_HOME$/.gradle/caches/modules-2/files-2.1/com.querydsl/querydsl-apt/5.0.0/d48657412f2b96d787bbe5ae393e33815c94b4d0/querydsl-apt-5.0.0-jakarta.jar" />
+          <entry name="$USER_HOME$/.gradle/caches/modules-2/files-2.1/jakarta.annotation/jakarta.annotation-api/2.1.1/48b9bda22b091b1f48b13af03fe36db3be6e1ae3/jakarta.annotation-api-2.1.1.jar" />
+          <entry name="$USER_HOME$/.gradle/caches/modules-2/files-2.1/jakarta.persistence/jakarta.persistence-api/3.1.0/66901fa1c373c6aff65c13791cc11da72060a8d6/jakarta.persistence-api-3.1.0.jar" />
+          <entry name="$USER_HOME$/.gradle/caches/modules-2/files-2.1/com.querydsl/querydsl-codegen/5.1.0/a8504ea51fbc2258543cedab6a37fe6039b2d20a/querydsl-codegen-5.1.0.jar" />
+          <entry name="$USER_HOME$/.gradle/caches/modules-2/files-2.1/com.querydsl/querydsl-core/5.1.0/be322c3fe98de8e7c204afb8860bfabd81a3bafd/querydsl-core-5.1.0.jar" />
+          <entry name="$USER_HOME$/.gradle/caches/modules-2/files-2.1/com.querydsl/codegen-utils/5.1.0/ba401554d613760617992eafb6cdba175c811e6f/codegen-utils-5.1.0.jar" />
+          <entry name="$USER_HOME$/.gradle/caches/modules-2/files-2.1/javax.inject/javax.inject/1/6975da39a7040257bd51d21a231b76c915872d38/javax.inject-1.jar" />
+          <entry name="$USER_HOME$/.gradle/caches/modules-2/files-2.1/io.github.classgraph/classgraph/4.8.146/360448a09bfa5689d89cfa97fea53b3fdefa9c23/classgraph-4.8.146.jar" />
+          <entry name="$USER_HOME$/.gradle/caches/modules-2/files-2.1/com.mysema.commons/mysema-commons-lang/0.2.4/d09c8489d54251a6c22fbce804bdd4a070557317/mysema-commons-lang-0.2.4.jar" />
+          <entry name="$USER_HOME$/.gradle/caches/modules-2/files-2.1/org.eclipse.jdt/ecj/3.26.0/4837be609a3368a0f7e7cf0dc1bdbc7fe94993de/ecj-3.26.0.jar" />
         </processorPath>
         <module name="grapeField.main" />
       </profile>

--- a/build.gradle
+++ b/build.gradle
@@ -52,6 +52,13 @@ dependencies {
 
     //이미지를 aws s3에 저장
     implementation 'io.awspring.cloud:spring-cloud-aws-starter-s3:3.3.0'
+
+    //QueryDsl을 사용하기 위한 gradle
+    implementation 'com.querydsl:querydsl-jpa:5.0.0:jakarta'
+    annotationProcessor "com.querydsl:querydsl-apt:5.0.0:jakarta"
+    annotationProcessor "jakarta.annotation:jakarta.annotation-api"
+    annotationProcessor "jakarta.persistence:jakarta.persistence-api"
+    implementation "com.querydsl:querydsl-collections:5.0.0" // GroupBy 사용 시 필요
 }
 
 tasks.named('test') {

--- a/src/main/java/com/example/grapefield/common/PageResponse.java
+++ b/src/main/java/com/example/grapefield/common/PageResponse.java
@@ -1,0 +1,35 @@
+package com.example.grapefield.common;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.data.domain.Page;
+
+import java.util.List;
+
+@Builder
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+public class PageResponse<T> {
+    private int page;
+    private int size;
+    private long totalElements;
+    private int totalPages;
+    private boolean hasNext;
+    private boolean hasPrevious;
+    private List<T> instances;
+
+    public static <T, R> PageResponse<R> from(Page<T> page, List<R> dtoList) {
+        return PageResponse.<R>builder()
+                .page(page.getNumber())
+                .size(page.getSize())
+                .totalElements(page.getTotalElements())
+                .totalPages(page.getTotalPages())
+                .hasNext(page.hasNext())
+                .hasPrevious(page.hasPrevious())
+                .instances(dtoList)
+                .build();
+    }
+}

--- a/src/main/java/com/example/grapefield/config/QueryDslConfig.java
+++ b/src/main/java/com/example/grapefield/config/QueryDslConfig.java
@@ -1,0 +1,19 @@
+package com.example.grapefield.config;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class QueryDslConfig {
+
+  @PersistenceContext
+  private EntityManager entityManager;
+
+  @Bean
+  public JPAQueryFactory jpaQueryFactory() {
+    return new JPAQueryFactory(entityManager);
+  }
+}

--- a/src/main/java/com/example/grapefield/config/SecurityConfig.java
+++ b/src/main/java/com/example/grapefield/config/SecurityConfig.java
@@ -50,14 +50,11 @@ public class SecurityConfig {
             }).deleteCookies("ATOKEN"));
         http.authorizeHttpRequests(authorizeRequests -> {
             authorizeRequests
-                    .requestMatchers("/user/logout", "/user/signup", "/login", "/logout", "/user/email_verify", "/user/email_verify/**").permitAll()
-                    .requestMatchers("/admin/**", "/events/register", "/user/**", "/post/register","/post/update/**", "/post/delete/**","/comment/register","/comment/update/**","/comment/delete/**").hasRole("ADMIN")
+                    .requestMatchers("/admin/**", "/events/register", "/events/update","/user/**", "/post/register","/post/update/**", "/post/delete/**","/comment/register","/comment/update/**","/comment/delete/**").hasRole("ADMIN")
                     .requestMatchers("/post/register","/post/update/**", "/post/delete/**","/comment/register","/comment/update/**","/comment/delete/**", "/user/**").hasRole("USER")
-//                    .requestMatchers("/user/**").hasRole("USER")
-//                    .anyRequest().permitAll()
+                    .requestMatchers("/user/logout", "/user/signup", "/login", "/logout", "/user/email_verify", "/user/email_verify/**", "/events/**").permitAll()
                     .requestMatchers("/swagger-ui.html", "/swagger-ui/**", "/v3/api-docs/**","/v3/api-docs", "/swagger-resources/**", "/webjars/**").permitAll()
                     .anyRequest().authenticated();
-
         });
 //        http.oauth2Login(config-> {
 //            config.successHandler(new OAuth2SuccessHandler());

--- a/src/main/java/com/example/grapefield/events/EventsController.java
+++ b/src/main/java/com/example/grapefield/events/EventsController.java
@@ -2,8 +2,10 @@ package com.example.grapefield.events;
 
 import com.example.grapefield.base.ApiErrorResponses;
 import com.example.grapefield.base.ApiSuccessResponses;
+import com.example.grapefield.common.PageResponse;
 import com.example.grapefield.events.model.entity.EventCategory;
 import com.example.grapefield.events.model.request.EventsRegisterReq;
+import com.example.grapefield.events.model.response.EventsCalendarListResp;
 import com.example.grapefield.events.model.response.EventsDetailResp;
 import com.example.grapefield.events.model.response.EventsListResp;
 import com.example.grapefield.events.post.model.request.PostRegisterReq;
@@ -15,6 +17,8 @@ import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.web.PageableDefault;
 import org.springframework.format.annotation.DateTimeFormat;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
@@ -29,6 +33,7 @@ import java.util.List;
 @RequestMapping("/events")
 @Tag(name="3. 공연/전시 기능", description = "공연/전시를 등록하고 목록 및 상세 정보를 확인")
 public class EventsController {
+  private final EventsService eventsService;
   @Operation(summary="공연/전시 등록", description = "공연 및 전시를 등록 합니다(관리자)")
   @ApiResponses(
       @ApiResponse(responseCode = "200", description = "공연/전시 등록 성공",
@@ -46,13 +51,9 @@ public class EventsController {
   @ApiSuccessResponses
   @ApiErrorResponses
   @GetMapping("/list")
-  public ResponseEntity<List<EventsListResp>> getEventsList(
-      @AuthenticationPrincipal User user) {
-    List<EventsListResp> dummyList = List.of(
-        new EventsListResp(1L,"웃는 남자", EventCategory.MUSICAL, LocalDateTime.now(), LocalDateTime.now(), "/sample/images/poster/poster1.jpg", "예술의전당 오페라극장"),
-        new EventsListResp(2L,"우는 남자", EventCategory.MUSICAL, LocalDateTime.now(), LocalDateTime.now(), "/sample/images/poster/poster1.jpg", "예술의전당 오페라극장")
-    );
-    return ResponseEntity.ok(dummyList);
+  public ResponseEntity<PageResponse<EventsListResp>> getEventList(@PageableDefault(page = 0, size = 30) Pageable pageable) {
+    PageResponse<EventsListResp> eventListPage = eventsService.getEventListWithPagination(pageable);
+    return ResponseEntity.ok(eventListPage);
   }
 
   //(캘린더용)날짜 선택하면 해당 날짜의 공연/전시 불러오기
@@ -60,14 +61,11 @@ public class EventsController {
   @ApiSuccessResponses
   @ApiErrorResponses
   @GetMapping("/calendar")
-  public ResponseEntity<List<EventsListResp>> getEventsByDate(
+  public ResponseEntity<List<EventsCalendarListResp>> getCalendarEvents(
           @RequestParam @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDateTime date
   ) {
-    List<EventsListResp> dummyList = List.of(
-            new EventsListResp(1L,"웃는 남자", EventCategory.MUSICAL, LocalDateTime.now(), LocalDateTime.now(), "/sample/images/poster/poster1.jpg", "예술의전당 오페라극장"),
-            new EventsListResp(2L,"우는 남자", EventCategory.MUSICAL, LocalDateTime.now(), LocalDateTime.now(), "/sample/images/poster/poster1.jpg", "예술의전당 오페라극장")
-    );
-    return ResponseEntity.ok(dummyList);
+    List<EventsCalendarListResp> eventList = eventsService.getCalendarEvents(date);
+    return ResponseEntity.ok(eventList);
   }
 
 

--- a/src/main/java/com/example/grapefield/events/EventsController.java
+++ b/src/main/java/com/example/grapefield/events/EventsController.java
@@ -27,6 +27,7 @@ import org.springframework.web.bind.annotation.*;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.List;
+import java.util.Map;
 
 @RequiredArgsConstructor
 @RestController
@@ -56,17 +57,30 @@ public class EventsController {
     return ResponseEntity.ok(eventListPage);
   }
 
-  //(캘린더용)날짜 선택하면 해당 날짜의 공연/전시 불러오기
-  @Operation(summary = "특정 날짜의 공연/전시 조회", description = "입력한 날짜에 진행 중인 공연/전시를 목록으로 반환합니다. (캘린더 전용)")
+  @Operation(summary = "캘린더 이벤트 조회", description = "해당 월의 예매 시작/종료 이벤트를 구분하여 조회합니다")
   @ApiSuccessResponses
   @ApiErrorResponses
   @GetMapping("/calendar")
-  public ResponseEntity<List<EventsCalendarListResp>> getCalendarEvents(
-          @RequestParam @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDateTime date
+  public ResponseEntity<Map<String, List<EventsCalendarListResp>>> getCalendarEvents(
+      @RequestParam @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDateTime date
   ) {
-    List<EventsCalendarListResp> eventList = eventsService.getCalendarEvents(date);
-    return ResponseEntity.ok(eventList);
+    Map<String, List<EventsCalendarListResp>> eventMap = eventsService.getCalendarEvents(date);
+    return ResponseEntity.ok(eventMap);
   }
+
+  //TODO : 캘린더 개별날짜 공연/전시 불러오기
+//  @Operation(summary = "특정 날짜 이벤트 조회", description = "특정 날짜의 예매 시작/종료 이벤트를 구분하여 조회합니다")
+//  @ApiSuccessResponses
+//  @ApiErrorResponses
+//  @GetMapping("/calendar/day")
+//  public ResponseEntity<Map<String, List<EventsCalendarListResp>>> getDailyEvents(
+//      @RequestParam @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDateTime date
+//  ) {
+//    Map<String, List<EventsCalendarListResp>> eventMap = eventsService.getEventsForDay(date);
+//    return ResponseEntity.ok(eventMap);
+//  }
+
+
 
 
   @Operation(summary = "공연/전시 상세 조회", description = "사이트에 등록된 공연 및 전시의 상세한 정보를 조회")

--- a/src/main/java/com/example/grapefield/events/EventsCustomRepository.java
+++ b/src/main/java/com/example/grapefield/events/EventsCustomRepository.java
@@ -1,0 +1,20 @@
+package com.example.grapefield.events;
+
+import com.example.grapefield.events.model.entity.EventCategory;
+import com.example.grapefield.events.model.entity.Events;
+import com.example.grapefield.events.model.entity.TicketVendor;
+import com.example.grapefield.events.model.response.EventsCalendarListResp;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+public interface EventsCustomRepository {
+  // 시작일 기준 이벤트 조회
+  List<EventsCalendarListResp> findEventsBySaleStartBetween(
+      LocalDateTime startDate, LocalDateTime endDate);
+
+  // 종료일 기준 이벤트 조회
+  List<EventsCalendarListResp> findEventsBySaleEndBetween(
+      LocalDateTime startDate, LocalDateTime endDate);
+
+}

--- a/src/main/java/com/example/grapefield/events/EventsCustomRepositoryImpl.java
+++ b/src/main/java/com/example/grapefield/events/EventsCustomRepositoryImpl.java
@@ -1,0 +1,71 @@
+package com.example.grapefield.events;
+
+import com.example.grapefield.events.model.entity.*;
+import com.example.grapefield.events.model.response.EventsCalendarListResp;
+import com.querydsl.core.BooleanBuilder;
+import com.querydsl.core.types.Projections;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Repository
+@RequiredArgsConstructor
+public class EventsCustomRepositoryImpl implements EventsCustomRepository {
+  private final JPAQueryFactory queryFactory;
+
+  @Override
+  public List<EventsCalendarListResp> findEventsBySaleStartBetween(LocalDateTime startDate, LocalDateTime endDate) {
+
+    QEvents events = QEvents.events;
+    QTicketInfo ticketInfo = QTicketInfo.ticketInfo;
+
+    BooleanBuilder whereBuilder = new BooleanBuilder();
+
+    // 예매 시작일이 해당 기간 내에 있는 경우
+    whereBuilder.and(ticketInfo.saleStart.between(startDate, endDate));
+
+    return queryFactory
+        .select(Projections.constructor(EventsCalendarListResp.class,
+            events.idx,
+            events.title,
+            events.category,
+            ticketInfo.saleStart,
+            ticketInfo.saleEnd,
+            ticketInfo.ticketVendor,
+            ticketInfo.isPresale))
+        .from(events)
+        .join(ticketInfo).on(ticketInfo.events.eq(events))
+        .where(whereBuilder)
+        .orderBy(ticketInfo.saleStart.asc())
+        .fetch();
+  }
+
+  @Override
+  public List<EventsCalendarListResp> findEventsBySaleEndBetween(LocalDateTime startDate, LocalDateTime endDate){
+    QEvents events = QEvents.events;
+    QTicketInfo ticketInfo = QTicketInfo.ticketInfo;
+
+    BooleanBuilder whereBuilder = new BooleanBuilder();
+
+    // 예매 종료일이 해당 기간 내에 있는 경우
+    whereBuilder.and(ticketInfo.saleEnd.between(startDate, endDate));
+
+    return queryFactory
+        .select(Projections.constructor(EventsCalendarListResp.class,
+            events.idx,
+            events.title,
+            events.category,
+            ticketInfo.saleStart,
+            ticketInfo.saleEnd,
+            ticketInfo.ticketVendor,
+            ticketInfo.isPresale))
+        .from(events)
+        .join(ticketInfo).on(ticketInfo.events.eq(events))
+        .where(whereBuilder)
+        .orderBy(ticketInfo.saleStart.asc())
+        .fetch();
+  }
+}

--- a/src/main/java/com/example/grapefield/events/EventsRepository.java
+++ b/src/main/java/com/example/grapefield/events/EventsRepository.java
@@ -3,5 +3,8 @@ package com.example.grapefield.events;
 import com.example.grapefield.events.model.entity.Events;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
+
 public interface EventsRepository extends JpaRepository<Events, Long> {
+    List<Events> getByDate();
 }

--- a/src/main/java/com/example/grapefield/events/EventsRepository.java
+++ b/src/main/java/com/example/grapefield/events/EventsRepository.java
@@ -1,10 +1,12 @@
 package com.example.grapefield.events;
 
+import com.example.grapefield.events.model.entity.EventCategory;
 import com.example.grapefield.events.model.entity.Events;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.List;
 
-public interface EventsRepository extends JpaRepository<Events, Long> {
-    List<Events> getByDate();
+public interface EventsRepository extends JpaRepository<Events, Long>, EventsCustomRepository {
+  List<Events> findByTitle(String title);
+  List<Events> findByCategory(EventCategory category);
 }

--- a/src/main/java/com/example/grapefield/events/EventsService.java
+++ b/src/main/java/com/example/grapefield/events/EventsService.java
@@ -1,7 +1,9 @@
 package com.example.grapefield.events;
 
 import com.example.grapefield.common.PageResponse;
+import com.example.grapefield.events.model.entity.EventCategory;
 import com.example.grapefield.events.model.entity.Events;
+import com.example.grapefield.events.model.entity.TicketVendor;
 import com.example.grapefield.events.model.request.EventsRegisterReq;
 import com.example.grapefield.events.model.response.EventsCalendarListResp;
 import com.example.grapefield.events.model.response.EventsListResp;
@@ -14,7 +16,9 @@ import org.springframework.stereotype.Service;
 
 import java.time.LocalDateTime;
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 @Service
 @RequiredArgsConstructor
@@ -45,8 +49,48 @@ public class EventsService {
     return PageResponse.from(eventDtoPage, eventDtoPage.getContent());
   }
 
-  public List<EventsCalendarListResp> getCalendarEvents(LocalDateTime date) {
-    List<Events> events = eventsRepository.getByDate();
-    List<EventsCalendarListResp> eventList = new ArrayList<>();
+  public Map<String, List<EventsCalendarListResp>> getCalendarEvents(
+      LocalDateTime date) {
+
+    LocalDateTime startOfMonth = date.withDayOfMonth(1).withHour(0).withMinute(0).withSecond(0);
+    LocalDateTime endOfMonth = date.withDayOfMonth(date.toLocalDate().lengthOfMonth())
+        .withHour(23).withMinute(59).withSecond(59);
+
+    // 시작일, 종료일 기준으로 각각 조회
+    List<EventsCalendarListResp> startEvents = eventsRepository.findEventsBySaleStartBetween(
+        startOfMonth, endOfMonth);
+
+    List<EventsCalendarListResp> endEvents = eventsRepository.findEventsBySaleEndBetween(
+        startOfMonth, endOfMonth);
+
+    // 결과 맵 구성
+    Map<String, List<EventsCalendarListResp>> result = new HashMap<>();
+    result.put("startEvents", startEvents);
+    result.put("endEvents", endEvents);
+
+    return result;
   }
+
+//  public Map<String, List<EventsCalendarListResp>> getFilteredCalendarEvents(
+//      LocalDateTime date, EventCategory category, Boolean isPresale, TicketVendor ticketVendor) {
+//
+//    LocalDateTime startOfMonth = date.withDayOfMonth(1).withHour(0).withMinute(0).withSecond(0);
+//    LocalDateTime endOfMonth = date.withDayOfMonth(date.toLocalDate().lengthOfMonth())
+//        .withHour(23).withMinute(59).withSecond(59);
+//
+//    // 시작일, 종료일 기준으로 각각 조회
+//    List<EventsCalendarListResp> startEvents = eventsRepository.findEventsBySaleStartBetween(
+//        startOfMonth, endOfMonth, category, isPresale, ticketVendor);
+//
+//    List<EventsCalendarListResp> endEvents = eventsRepository.findEventsBySaleEndBetween(
+//        startOfMonth, endOfMonth, category, isPresale, ticketVendor);
+//
+//    // 결과 맵 구성
+//    Map<String, List<EventsCalendarListResp>> result = new HashMap<>();
+//    result.put("startEvents", startEvents);
+//    result.put("endEvents", endEvents);
+//
+//    return result;
+//  }
+
 }

--- a/src/main/java/com/example/grapefield/events/EventsService.java
+++ b/src/main/java/com/example/grapefield/events/EventsService.java
@@ -1,11 +1,20 @@
 package com.example.grapefield.events;
 
+import com.example.grapefield.common.PageResponse;
 import com.example.grapefield.events.model.entity.Events;
 import com.example.grapefield.events.model.request.EventsRegisterReq;
+import com.example.grapefield.events.model.response.EventsCalendarListResp;
+import com.example.grapefield.events.model.response.EventsListResp;
 import com.example.grapefield.events.post.BoardRepository;
 import com.example.grapefield.events.post.model.entity.Board;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
+
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
 
 @Service
 @RequiredArgsConstructor
@@ -15,8 +24,29 @@ public class EventsService {
 
   public Long eventsRegister(EventsRegisterReq request) {
     Events events = eventsRepository.save(request.toEntity());
+    //events의 idx를 받아서 board 추가
     Board board = Board.builder().events(events).title(events.getTitle()).build();
     boardRepository.save(board);
+  //TODO : 채팅방 추가
     return events.getIdx();
+  }
+
+  public PageResponse<EventsListResp> getEventListWithPagination(Pageable pageable) {
+    Page<Events> eventPage = eventsRepository.findAll(pageable);
+    Page<EventsListResp> eventDtoPage = eventPage.map(event -> EventsListResp.builder()
+            .idx(event.getIdx())
+            .title(event.getTitle())
+            .category(event.getCategory())
+            .startDate(event.getStartDate())
+            .endDate(event.getEndDate())
+            .posterImgUrl(event.getPosterImgUrl())
+            .venue(event.getVenue())
+            .build());
+    return PageResponse.from(eventDtoPage, eventDtoPage.getContent());
+  }
+
+  public List<EventsCalendarListResp> getCalendarEvents(LocalDateTime date) {
+    List<Events> events = eventsRepository.getByDate();
+    List<EventsCalendarListResp> eventList = new ArrayList<>();
   }
 }

--- a/src/main/java/com/example/grapefield/events/model/response/EventsCalendarListResp.java
+++ b/src/main/java/com/example/grapefield/events/model/response/EventsCalendarListResp.java
@@ -1,0 +1,29 @@
+package com.example.grapefield.events.model.response;
+
+import com.example.grapefield.events.model.entity.EventCategory;
+import com.example.grapefield.events.model.entity.TicketVendor;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@AllArgsConstructor
+@NoArgsConstructor
+@Getter
+@Schema(description="공연/전시 목록 정보 응답")
+public class EventsCalendarListResp {
+    @Schema(example = "1")
+    private Long idx;
+    @Schema(description="공연 제목", example = "웃는 남자")
+    private String title;
+    @Schema(example="뮤지컬")
+    private EventCategory category;
+    @Schema(description="예매 시작일",  example = "2024-12-30T00:00:00")
+    private LocalDateTime saleStart;
+    @Schema(description="예메처 정보", example="인터파크")
+    private TicketVendor ticketVendor;
+    @Schema(description = "선예매 여부", example = "true")
+    private Boolean isPresale;
+}

--- a/src/main/java/com/example/grapefield/events/model/response/EventsCalendarListResp.java
+++ b/src/main/java/com/example/grapefield/events/model/response/EventsCalendarListResp.java
@@ -22,6 +22,8 @@ public class EventsCalendarListResp {
     private EventCategory category;
     @Schema(description="예매 시작일",  example = "2024-12-30T00:00:00")
     private LocalDateTime saleStart;
+    @Schema(description="예매 종료",  example = "2025-01-15T00:00:00")
+    private LocalDateTime saleEnd;
     @Schema(description="예메처 정보", example="인터파크")
     private TicketVendor ticketVendor;
     @Schema(description = "선예매 여부", example = "true")

--- a/src/main/java/com/example/grapefield/events/model/response/EventsListResp.java
+++ b/src/main/java/com/example/grapefield/events/model/response/EventsListResp.java
@@ -28,4 +28,6 @@ public class EventsListResp {
   private String posterImgUrl;
   @Schema(description="공연/전시 위치", example = "예술의전당 오페라극장")
   private String venue;
+  @Schema(description="즐겨찾기 수", example = "전시/공연의 유저가 즐겨찾기한 수")
+  private int interestCtn;
 }

--- a/src/main/java/com/example/grapefield/events/model/response/EventsListResp.java
+++ b/src/main/java/com/example/grapefield/events/model/response/EventsListResp.java
@@ -3,15 +3,16 @@ package com.example.grapefield.events.model.response;
 import com.example.grapefield.events.model.entity.EventCategory;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import java.time.LocalDateTime;
-
 
 @AllArgsConstructor
 @NoArgsConstructor
 @Getter
 @Schema(description="공연/전시 목록 정보 응답")
+@Builder
 public class EventsListResp {
   @Schema(example = "1")
   private Long idx;

--- a/src/main/java/com/example/grapefield/events/model/response/TicketInfoDetailResp.java
+++ b/src/main/java/com/example/grapefield/events/model/response/TicketInfoDetailResp.java
@@ -17,9 +17,9 @@ public class TicketInfoDetailResp {
   private String ticketLink;
   @Schema(description = "선예매 여부", example = "true")
   private Boolean isPresale;
-  @Schema(description="티켓 판매 시작일",  example = "2024-12-30T00:00:00")
+  @Schema(description="예매 시작일",  example = "2024-12-30T00:00:00")
   private LocalDateTime saleStart;
-  @Schema(description="티켓 판매 종료일",  example = "2025-03-09T00:00:00")
+  @Schema(description="예매 종료일",  example = "2025-03-09T00:00:00")
   private LocalDateTime saleEnd;
   @Schema(description="예메처 정보", example="인터파크")
   private TicketVendor ticketVendor;


### PR DESCRIPTION
## #️⃣ Issue Number
#13 

## 📝 요약(Summary)
메인 페이지에서 이벤트를 예매일 시작일과 마지막일 기준으로 표시하려는데 아직 TicketInfo가 null이라서
받아오는 정보가 없어 추후 수정 필요

## 🛠️ PR 유형
어떤 변경 사항이 있나요?
- [ ] 새로운 기능 추가
- [ ] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## 📸스크린샷 (선택)

## 💬 공유사항 to 리뷰어

<!--- 리뷰어가 중점적으로 봐줬으면 좋겠는 부분이 있으면 적어주세요. -->
<!--- 논의해야할 부분이 있다면 적어주세요.-->
<!--- ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요? -->

## ✅ PR Checklist

PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [ ] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).