### PR TITLE
Feat/chat/kafka consumer

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,22 @@
+version: '3'
+services:
+  zookeeper:
+    image: confluentinc/cp-zookeeper:7.5.0
+    container_name: zookeeper
+    ports:
+      - "2181:2181"
+    environment:
+      ZOOKEEPER_CLIENT_PORT: 2181
+      ZOOKEEPER_TICK_TIME: 2000
+
+  kafka:
+    image: confluentinc/cp-kafka:7.5.0
+    container_name: kafka
+    ports:
+      - "9092:9092"
+    environment:
+      KAFKA_BROKER_ID: 1
+      KAFKA_ZOOKEEPER_CONNECT: zookeeper:2181
+      KAFKA_ADVERTISED_LISTENERS: PLAINTEXT://localhost:9092
+      KAFKA_LISTENER_SECURITY_PROTOCOL_MAP: PLAINTEXT:PLAINTEXT
+      KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR: 1

--- a/src/main/java/com/example/grapefield/chat/controller/ChatTestController.java
+++ b/src/main/java/com/example/grapefield/chat/controller/ChatTestController.java
@@ -1,0 +1,4 @@
+package com.example.grapefield.chat.controller;
+
+public class ChatTestController {
+}

--- a/src/main/java/com/example/grapefield/chat/controller/ChatTestController.java
+++ b/src/main/java/com/example/grapefield/chat/controller/ChatTestController.java
@@ -1,4 +1,24 @@
 package com.example.grapefield.chat.controller;
 
+
+import com.example.grapefield.chat.model.request.ChatMessageKafkaReq;
+import com.example.grapefield.chat.model.request.ChatMessageReq;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/chat-test")
+@RequiredArgsConstructor
 public class ChatTestController {
+
+    private final KafkaTemplate<String, ChatMessageKafkaReq> kafkaTemplate;
+
+    @PostMapping("/send")
+    public ResponseEntity<String> sendTestMessage(@RequestBody ChatMessageReq req) {
+        ChatMessageKafkaReq event = new ChatMessageKafkaReq(req.getRoomIdx(), req.getSendUserIdx(), req.getContent());
+        kafkaTemplate.send("chat-message-topic", event);
+        return ResponseEntity.ok("Kafka 메시지 전송 완료");
+    }
 }

--- a/src/main/java/com/example/grapefield/chat/kafka/ChatKafkaConsumer.java
+++ b/src/main/java/com/example/grapefield/chat/kafka/ChatKafkaConsumer.java
@@ -1,0 +1,25 @@
+package com.example.grapefield.chat.kafka;
+
+import com.example.grapefield.chat.model.request.ChatMessageKafkaReq;
+import com.example.grapefield.chat.service.ChatMessageService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.kafka.annotation.KafkaListener;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class ChatKafkaConsumer {
+
+    private final ChatMessageService chatMessageService;
+
+    @KafkaListener(topics = "chat-message-topic", groupId = "chat-group")
+    public void consume(ChatMessageKafkaReq message) {
+        log.info("✅ Kafka 메시지 수신: roomIdx={}, userIdx={}, content={}",
+                message.getRoomIdx(), message.getSendUserIdx(), message.getContent());
+
+        chatMessageService.saveMessage(message);
+    }
+}
+

--- a/src/main/java/com/example/grapefield/chat/service/ChatMessageService.java
+++ b/src/main/java/com/example/grapefield/chat/service/ChatMessageService.java
@@ -1,0 +1,54 @@
+package com.example.grapefield.chat.service;
+
+import com.example.grapefield.chat.model.entity.ChatMessageBase;
+import com.example.grapefield.chat.model.entity.ChatMessageCurrent;
+import com.example.grapefield.chat.model.entity.ChatRoom;
+import com.example.grapefield.chat.model.request.ChatMessageKafkaReq;
+import com.example.grapefield.chat.repository.ChatMessageBaseRepository;
+import com.example.grapefield.chat.repository.ChatMessageCurrentRepository;
+import com.example.grapefield.chat.repository.ChatRoomRepository;
+import com.example.grapefield.user.model.entity.User;
+import com.example.grapefield.user.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class ChatMessageService {
+
+    private final ChatMessageBaseRepository baseRepository;
+    private final ChatMessageCurrentRepository currentRepository;
+    private final ChatRoomRepository chatRoomRepository;
+    private final UserRepository userRepository;
+
+    public void saveMessage(ChatMessageKafkaReq req) {
+        // 1. 채팅방 정보 가져오기
+        ChatRoom room = chatRoomRepository.findById(req.getRoomIdx())
+                .orElseThrow(() -> new IllegalArgumentException("채팅방이 존재하지 않습니다."));
+
+        // 2. 사용자 정보 가져오기
+        User user = userRepository.findById(req.getSendUserIdx())
+                .orElseThrow(() -> new IllegalArgumentException("사용자가 존재하지 않습니다."));
+
+        // 3. 메시지 base 저장 (자동 생성된 IDX 사용)
+        ChatMessageBase base = baseRepository.save(ChatMessageBase.builder().build());
+
+        // 4. 메시지 current 저장 (base 포함)
+        ChatMessageCurrent current = ChatMessageCurrent.builder()
+                .base(base)
+                .chatRoom(room)
+                .user(user)
+                .content(req.getContent())
+                .createdAt(base.getCreatedAt())
+                .isHighlighted(false)
+                .build();
+
+        currentRepository.save(current);
+
+        // 로그 확인
+        log.info("✅ 채팅 메시지 저장 완료 | baseId={}, user={}, room={}, content={}",
+                base.getMessageIdx(), user.getUsername(), room.getRoomName(), req.getContent());
+    }
+}

--- a/src/main/java/com/example/grapefield/config/SecurityConfig.java
+++ b/src/main/java/com/example/grapefield/config/SecurityConfig.java
@@ -35,7 +35,7 @@ public class SecurityConfig {
     http.csrf(csrf -> csrf
         .csrfTokenRepository(CookieCsrfTokenRepository.withHttpOnlyFalse())
         // 인증이 필요 없는 경로는 CSRF 보호 제외 (RESTful API 호출 용이성을 위해)
-        .ignoringRequestMatchers("/user/signup", "/login", "/user/email_verify/**")
+        .ignoringRequestMatchers("/user/signup", "/login", "/user/email_verify/**", "/chat-test/**")
     );
 
     // 기본 HTTP 인증과 폼 로그인 비활성화 (JWT 사용)
@@ -78,7 +78,7 @@ public class SecurityConfig {
               "/user/**").hasAnyRole("USER", "ADMIN")
           // Swagger UI 접근 허용
           .requestMatchers("/swagger-ui.html", "/swagger-ui/**", "/v3/api-docs/**",
-              "/v3/api-docs", "/swagger-resources/**", "/webjars/**").permitAll()
+              "/v3/api-docs", "/swagger-resources/**", "/webjars/**", "/chat-test/**").permitAll()
           // 기타 모든 요청은 인증 필요
           .anyRequest().authenticated();
     });

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,4 +1,11 @@
 spring:
+  kafka:
+    producer:
+      value-serializer: org.springframework.kafka.support.serializer.JsonSerializer
+    consumer:
+      value-deserializer: org.springframework.kafka.support.serializer.JsonDeserializer
+      properties:
+        spring.json.trusted.packages: '*'
   application:
     name: grapefield
   datasource:


### PR DESCRIPTION
## #️⃣ Issue Number
#27 Kafka Consumer : 채팅 메시지 수신 및 저장
#28 ChatMessageService 구현 : 메시지 저장 처리
#29 메시지 저장용 repository 생성
#31 카프카 컨슈머 테스트를 위한 구현

## 📝 요약(Summary)
카프카 컨슈머 부분을 구현, 테스트까지 진행해보려고 나머지 테스트 컨트롤러도 추가, 확인 후 수정 예정

## 🛠️ PR 유형
어떤 변경 사항이 있나요?
- [x] 새로운 기능 추가
- [x] 주석 추가 및 수정
- [x] 테스트 추가, 테스트 리팩토링

## 💬 공유사항 to 리뷰어
확인해주세용~

## ✅ PR Checklist
- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.