### PR TITLE
Feat/chat/kafka consumer 카프카 토픽 생성 로직 분리

### DIFF
--- a/src/main/java/com/example/grapefield/chat/controller/ChatWebSocketController.java
+++ b/src/main/java/com/example/grapefield/chat/controller/ChatWebSocketController.java
@@ -3,6 +3,8 @@ package com.example.grapefield.chat.controller;
 import com.example.grapefield.chat.kafka.ChatKafkaProducer;
 import com.example.grapefield.chat.model.request.ChatMessageKafkaReq;
 import com.example.grapefield.chat.model.request.ChatMessageReq;
+import com.example.grapefield.chat.service.ChatMessageService;
+import com.example.grapefield.chat.service.ChatRoomService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
@@ -41,6 +43,7 @@ public class ChatWebSocketController {
     }
     */
     private final ChatKafkaProducer chatKafkaProducer;
+    private final ChatRoomService chatRoomService;
 
     @Autowired
     private SimpMessagingTemplate messagingTemplate;
@@ -51,6 +54,9 @@ public class ChatWebSocketController {
         // 개발 테스트용 로그
         log.info("WebSocket 메시지 수신: roomIdx={}, content={}",
                 chatMessageReq.getRoomIdx(), chatMessageReq.getContent());
+
+        // ✅ 1. 채팅방이 DB와 Kafka 모두 존재하는지 보장
+        chatRoomService.ensureRoomExists(chatMessageReq.getRoomIdx(), "기본 채팅방");
 
         // 1. kafka로 메시지 전송
         //  Kafka의 이벤트에 담아서 클라이언트로부터의 메시지를 kafka로 전송

--- a/src/main/java/com/example/grapefield/chat/service/ChatRoomService.java
+++ b/src/main/java/com/example/grapefield/chat/service/ChatRoomService.java
@@ -2,10 +2,10 @@ package com.example.grapefield.chat.service;
 
 import com.example.grapefield.chat.model.entity.ChatRoom;
 import com.example.grapefield.chat.repository.ChatRoomRepository;
-import org.apache.kafka.clients.admin.AdminClient;
-import org.apache.kafka.clients.admin.NewTopic;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.apache.kafka.clients.admin.AdminClient;
+import org.apache.kafka.clients.admin.NewTopic;
 import org.springframework.stereotype.Service;
 
 import java.time.LocalDateTime;
@@ -19,23 +19,26 @@ public class ChatRoomService {
     private final ChatRoomRepository chatRoomRepository;
     private final AdminClient adminClient;
 
-    public ChatRoom createRoom(Long roomIdx, String roomName) {
-        // 1. DB에 채팅방 생성 (중복 방지)
-        if (chatRoomRepository.existsById(roomIdx)) {
-            log.info("채팅방 이미 존재: {}", roomIdx);
-            return chatRoomRepository.findById(roomIdx).get();
-        }
+    public ChatRoom ensureRoomExists(Long roomIdx, String roomName) {
+        return chatRoomRepository.findById(roomIdx).orElseGet(() -> {
+            ChatRoom room = ChatRoom.builder()
+                    .idx(roomIdx)
+                    .roomName(roomName)
+                    .createdAt(LocalDateTime.now())
+                    .heartCnt(0L)
+                    .build();
 
-        ChatRoom room = ChatRoom.builder()
-                .idx(roomIdx)
-                .roomName(roomName)
-                .createdAt(LocalDateTime.now())
-                .heartCnt(0L)
-                .build();
-        chatRoomRepository.save(room);
-        log.info("✅ 채팅방 DB 저장 완료");
+            chatRoomRepository.save(room);
+            log.info("✅ 채팅방 DB 저장 완료: {}", roomIdx);
 
-        // 2. Kafka 토픽 생성
+            // Kafka 토픽도 보장
+            createKafkaTopicIfNotExists(roomIdx);
+
+            return room;
+        });
+    }
+
+    private void createKafkaTopicIfNotExists(Long roomIdx) {
         String topicName = "chat-" + roomIdx;
         try {
             var existingTopics = adminClient.listTopics().names().get();
@@ -48,8 +51,5 @@ public class ChatRoomService {
         } catch (Exception e) {
             log.warn("⚠️ Kafka 토픽 생성 중 에러: {}", e.getMessage());
         }
-
-        return room;
     }
 }
-


### PR DESCRIPTION
## #️⃣ Issue Number
#41 카프카 토픽 생성 로직 분리

## 📝 요약(Summary)
카프카 토픽 생성 로직을 분리하고, websocketcontroller에서 서비스를 호출해 서비스단에서 처리하도록 수정, 서비스 단에서 토픽 생성과 db확인 로직을 분리

## 🛠️ PR 유형
어떤 변경 사항이 있나요?
- [X] 새로운 기능 추가
- [X] 코드 리팩토링
- [X] 주석 추가 및 수정
- [ ] 파일 혹은 폴더 삭제

## 📸스크린샷 (선택)

## 💬 공유사항 to 리뷰어
처리하는 다른 더 좋은 방법이 있다면 공유 부탁드립니다~

## ✅ PR Checklist
- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.