### PR TITLE
[#43] 채팅방 입장(chatroom_member 테이블 관련) 로직 구현

### DIFF
--- a/src/main/java/com/example/grapefield/chat/controller/ChatRoomMemberController.java
+++ b/src/main/java/com/example/grapefield/chat/controller/ChatRoomMemberController.java
@@ -1,0 +1,23 @@
+package com.example.grapefield.chat.controller;
+
+import com.example.grapefield.chat.service.ChatRoomMemberService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/chatroom")
+public class ChatRoomMemberController {
+
+    private final ChatRoomMemberService chatRoomMemberService;
+
+    @PostMapping("/join/{roomIdx}")
+    public ResponseEntity<String> joinRoom(
+            @PathVariable Long roomIdx,
+            @RequestParam Long userIdx
+    ) {
+        chatRoomMemberService.joinRoom(userIdx, roomIdx);
+        return ResponseEntity.ok("채팅방 입장 완료");
+    }
+}

--- a/src/main/java/com/example/grapefield/chat/model/entity/ChatroomMember.java
+++ b/src/main/java/com/example/grapefield/chat/model/entity/ChatroomMember.java
@@ -29,4 +29,13 @@ public class ChatroomMember {
     @JoinColumn(name = "user_idx")
     private User user;
 
+    public void updateLastActiveAt(LocalDateTime newTime) {
+        this.lastActiveAt = newTime;
+    }
+
+    // (추후 필요하면 읽음 시간 갱신도 추가 가능)
+    public void updateLastReadAt(LocalDateTime time) {
+        this.lastReadAt = time;
+    }
+
 }

--- a/src/main/java/com/example/grapefield/chat/repository/ChatRoomMemberRepository.java
+++ b/src/main/java/com/example/grapefield/chat/repository/ChatRoomMemberRepository.java
@@ -1,0 +1,15 @@
+package com.example.grapefield.chat.repository;
+
+import com.example.grapefield.chat.model.entity.ChatRoom;
+import com.example.grapefield.chat.model.entity.ChatroomMember;
+import com.example.grapefield.user.model.entity.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+
+import java.util.Optional;
+
+
+public interface ChatRoomMemberRepository extends JpaRepository<ChatroomMember, Long> {
+    // 유저가 해당 채팅방에 이미 참여한 적이 있는지 확인
+    Optional<ChatroomMember> findByChatRoomAndUser(ChatRoom chatRoom, User user);
+}

--- a/src/main/java/com/example/grapefield/chat/service/ChatRoomMemberService.java
+++ b/src/main/java/com/example/grapefield/chat/service/ChatRoomMemberService.java
@@ -1,0 +1,51 @@
+package com.example.grapefield.chat.service;
+
+import com.example.grapefield.chat.model.entity.ChatRoom;
+import com.example.grapefield.chat.model.entity.ChatroomMember;
+import com.example.grapefield.chat.repository.ChatRoomMemberRepository;
+import com.example.grapefield.chat.repository.ChatRoomRepository;
+import com.example.grapefield.user.model.entity.User;
+import com.example.grapefield.user.repository.UserRepository;
+import jakarta.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+import java.time.LocalDateTime;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class ChatRoomMemberService {
+
+    private final ChatRoomRepository chatRoomRepository;
+    private final UserRepository userRepository;
+    private final ChatRoomMemberRepository memberRepository;
+
+    @Transactional
+    public void joinRoom(Long userIdx, Long roomIdx) {
+        ChatRoom room = chatRoomRepository.findById(roomIdx)
+                .orElseThrow(() -> new IllegalArgumentException("채팅방이 존재하지 않습니다."));
+        User user = userRepository.findById(userIdx)
+                .orElseThrow(() -> new IllegalArgumentException("사용자가 존재하지 않습니다."));
+
+        memberRepository.findByChatRoomAndUser(room, user)
+                .ifPresentOrElse(
+                        member -> {
+                            member.updateLastActiveAt(LocalDateTime.now());
+                            log.info("✅ 재입장 → lastActiveAt 갱신됨");
+                        },
+                        () -> {
+                            ChatroomMember newMember = ChatroomMember.builder()
+                                    .chatRoom(room)
+                                    .user(user)
+                                    .lastActiveAt(LocalDateTime.now())
+                                    .lastReadAt(null)
+                                    .mute(false)
+                                    .build();
+                            memberRepository.save(newMember);
+                            log.info("🆕 최초입장 → ChatroomMember 저장됨");
+                        }
+                );
+    }
+}

--- a/src/main/java/com/example/grapefield/config/SecurityConfig.java
+++ b/src/main/java/com/example/grapefield/config/SecurityConfig.java
@@ -35,7 +35,7 @@ public class SecurityConfig {
     http.csrf(csrf -> csrf
         .csrfTokenRepository(CookieCsrfTokenRepository.withHttpOnlyFalse())
         // 인증이 필요 없는 경로는 CSRF 보호 제외 (RESTful API 호출 용이성을 위해)
-        .ignoringRequestMatchers("/user/signup", "/login", "/user/email_verify/**", "/chat-test/**")
+        .ignoringRequestMatchers("/user/signup", "/login", "/user/email_verify/**", "/chat-test/**", "/chatroom/**")
     );
 
     // 기본 HTTP 인증과 폼 로그인 비활성화 (JWT 사용)
@@ -78,7 +78,7 @@ public class SecurityConfig {
               "/user/**").hasAnyRole("USER", "ADMIN")
           // Swagger UI 접근 허용
           .requestMatchers("/swagger-ui.html", "/swagger-ui/**", "/v3/api-docs/**",
-              "/v3/api-docs", "/swagger-resources/**", "/webjars/**", "/chat-test/**", "/ws/**").permitAll()
+              "/v3/api-docs", "/swagger-resources/**", "/webjars/**", "/chat-test/**", "/ws/**", "/chatroom/**").permitAll()
           // 기타 모든 요청은 인증 필요
           .anyRequest().authenticated();
     });


### PR DESCRIPTION
## #️⃣ Issue Number
#43 채팅방 입장 로직 구현

## 📝 요약(Summary)
사용자가 채팅방 입장 시 chatroom_member 테이블에 저장되는 로직 구현, 채팅을 보낼 시 마지막 활동 시간이 업데이트 되도록 로직 수정
+ 채팅을 보낼 때 마다 last_active_at 칼럼의 값이 업데이트 되는 것을 확인함

## 🛠️ PR 유형
어떤 변경 사항이 있나요?
- [x] 새로운 기능 추가
- [x] 코드 리팩토링
- [x] 주석 추가 및 수정
- [x] 테스트 추가, 테스트 리팩토링

## 📸스크린샷 (선택)
![image](https://github.com/user-attachments/assets/a4e09697-5fb9-4c82-865d-7cbae3b9b3fd)
![image](https://github.com/user-attachments/assets/5ead724e-a042-4c56-9516-f69b4eda3fc3)



## 💬 공유사항 to 리뷰어
로직 수정 부분은 추후에 의논하면 좋을 것 같아용 보시고 의견 주세요~

## ✅ PR Checklist
- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.