### PR TITLE
[fix] 공연/전시 추가되면 채팅방도 함께 초기화되도록 수정

### DIFF
--- a/src/main/java/com/example/grapefield/common/BoardInitializer.java
+++ b/src/main/java/com/example/grapefield/common/BoardInitializer.java
@@ -1,6 +1,6 @@
 package com.example.grapefield.common;
 
-import com.example.grapefield.events.EventsRepository;
+import com.example.grapefield.events.repository.EventsRepository;
 import com.example.grapefield.events.model.entity.Events;
 import com.example.grapefield.events.post.repository.BoardRepository;
 import com.example.grapefield.events.post.model.entity.Board;

--- a/src/main/java/com/example/grapefield/common/EventResourceInitializer.java
+++ b/src/main/java/com/example/grapefield/common/EventResourceInitializer.java
@@ -1,5 +1,7 @@
 package com.example.grapefield.common;
 
+import com.example.grapefield.chat.model.entity.ChatRoom;
+import com.example.grapefield.chat.repository.ChatRoomRepository;
 import com.example.grapefield.events.repository.EventsRepository;
 import com.example.grapefield.events.model.entity.Events;
 import com.example.grapefield.events.post.repository.BoardRepository;
@@ -10,25 +12,41 @@ import org.springframework.boot.ApplicationArguments;
 import org.springframework.boot.ApplicationRunner;
 import org.springframework.stereotype.Component;
 
+import java.time.LocalDateTime;
 import java.util.List;
 
 @Component
 @RequiredArgsConstructor
 @Transactional
-public class BoardInitializer implements ApplicationRunner {
+public class EventResourceInitializer implements ApplicationRunner {
 
   private final EventsRepository eventsRepository;
   private final BoardRepository boardRepository;
+  private final ChatRoomRepository chatRoomRepository;
 
-  //TODO : 채팅방도 추가 필요
   @Override
   public void run(ApplicationArguments args) {
     List<Events> allEvents = eventsRepository.findAll();
 
     for (Events events : allEvents) {
+      // 게시판 초기화
       if (!boardRepository.existsById(events.getIdx())) {
-        Board board = Board.builder().events(events).title(events.getTitle()).build();
+        Board board = Board.builder()
+            .events(events)
+            .title(events.getTitle())
+            .build();
         boardRepository.save(board);
+      }
+
+      // 채팅방 초기화
+      if (!chatRoomRepository.existsById(events.getIdx())) {
+        ChatRoom chatRoom = ChatRoom.builder()
+            .events(events)
+            .roomName(events.getTitle() + " 채팅방")
+            .createdAt(LocalDateTime.now())
+            .heartCnt(0L)
+            .build();
+        chatRoomRepository.save(chatRoom);
       }
     }
   }

--- a/src/main/java/com/example/grapefield/config/SecurityConfig.java
+++ b/src/main/java/com/example/grapefield/config/SecurityConfig.java
@@ -69,7 +69,7 @@ public class SecurityConfig {
     http.authorizeHttpRequests(authorizeRequests -> {
       authorizeRequests
           // 인증 없이 접근 가능한 경로
-          .requestMatchers("/user/signup", "/login", "/logout", "/user/email_verify", "/user/email_verify/**", "/events/**", "/participant/**","/post/list/**", "/post/**", "/comment/**").permitAll()
+          .requestMatchers("/user/signup", "/login", "/logout", "/user/email_verify", "/user/email_verify/**", "/events/**", "/participant/**","/post/list/**", "/post/**", "/comment/**", "/review/**").permitAll()
           // Swagger UI 접근 허용
           .requestMatchers("/swagger-ui.html", "/swagger-ui/**", "/v3/api-docs/**",
               "/v3/api-docs", "/swagger-resources/**", "/webjars/**").permitAll()
@@ -78,7 +78,7 @@ public class SecurityConfig {
           // 일반 사용자 권한 필요
           .requestMatchers("/post/register", "/post/update/**", "/post/delete/**",
               "/comment/register", "/comment/update/**", "/comment/delete/**",
-              "/user/**").hasAnyRole("USER", "ADMIN")
+              "/user/**", "/review/register", "/review/udadte", "/review/delete").hasAnyRole("USER", "ADMIN")
           // 기타 모든 요청은 인증 필요
           .anyRequest().authenticated();
     });

--- a/src/main/java/com/example/grapefield/events/EventsService.java
+++ b/src/main/java/com/example/grapefield/events/EventsService.java
@@ -7,6 +7,8 @@ import com.example.grapefield.events.model.request.EventsRegisterReq;
 import com.example.grapefield.events.model.response.*;
 import com.example.grapefield.events.post.repository.BoardRepository;
 import com.example.grapefield.events.post.model.entity.Board;
+import com.example.grapefield.events.repository.EventsImgRepository;
+import com.example.grapefield.events.repository.EventsRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;

--- a/src/main/java/com/example/grapefield/events/model/entity/Events.java
+++ b/src/main/java/com/example/grapefield/events/model/entity/Events.java
@@ -4,6 +4,7 @@ import com.example.grapefield.chat.model.entity.ChatRoom;
 import com.example.grapefield.events.participant.model.entity.EventsCast;
 import com.example.grapefield.events.participant.model.entity.EventsParticipation;
 import com.example.grapefield.events.post.model.entity.Board;
+import com.example.grapefield.events.review.model.entity.Review;
 import jakarta.persistence.*;
 import lombok.AllArgsConstructor;
 import lombok.Builder;

--- a/src/main/java/com/example/grapefield/events/participant/ParticipantService.java
+++ b/src/main/java/com/example/grapefield/events/participant/ParticipantService.java
@@ -1,8 +1,6 @@
 package com.example.grapefield.events.participant;
 
-import com.example.grapefield.events.EventsRepository;
-import com.example.grapefield.events.model.response.EventsDetailResp;
-import com.example.grapefield.events.participant.model.response.OrganizationListResp;
+import com.example.grapefield.events.repository.EventsRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 

--- a/src/main/java/com/example/grapefield/events/post/CommentController.java
+++ b/src/main/java/com/example/grapefield/events/post/CommentController.java
@@ -50,8 +50,8 @@ public class CommentController {
   @GetMapping("/{idx}")
   public ResponseEntity<PageResponse<CommentListResp>> getCommentList(@PathVariable Long idx, @PageableDefault(size = 10, sort = "createdAt", direction = Sort.Direction.DESC) Pageable pageable, @AuthenticationPrincipal CustomUserDetails principal) {
     User user = (principal != null) ? principal.getUser() : null;
-    Page<CommentListResp> postPage = commentService.getCommentList(idx, pageable, user);
-    PageResponse<CommentListResp> response = PageResponse.from(postPage, postPage.getContent());
+    Page<CommentListResp> commentPage = commentService.getCommentList(idx, pageable, user);
+    PageResponse<CommentListResp> response = PageResponse.from(commentPage, commentPage.getContent());
     return ResponseEntity.ok(response);
   }
 

--- a/src/main/java/com/example/grapefield/events/repository/EventsCustomRepository.java
+++ b/src/main/java/com/example/grapefield/events/repository/EventsCustomRepository.java
@@ -1,13 +1,10 @@
-package com.example.grapefield.events;
+package com.example.grapefield.events.repository;
 
 import com.example.grapefield.events.model.entity.EventCategory;
-import com.example.grapefield.events.model.entity.Events;
-import com.example.grapefield.events.model.entity.TicketVendor;
 import com.example.grapefield.events.model.response.EventsCalendarListResp;
 import com.example.grapefield.events.model.response.EventsDetailResp;
 import com.example.grapefield.events.model.response.EventsListResp;
 import com.example.grapefield.events.model.response.EventsTicketScheduleListResp;
-import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
 

--- a/src/main/java/com/example/grapefield/events/repository/EventsCustomRepositoryImpl.java
+++ b/src/main/java/com/example/grapefield/events/repository/EventsCustomRepositoryImpl.java
@@ -1,4 +1,4 @@
-package com.example.grapefield.events;
+package com.example.grapefield.events.repository;
 
 import com.example.grapefield.events.model.entity.*;
 import com.example.grapefield.events.model.response.*;

--- a/src/main/java/com/example/grapefield/events/repository/EventsImgRepository.java
+++ b/src/main/java/com/example/grapefield/events/repository/EventsImgRepository.java
@@ -1,4 +1,4 @@
-package com.example.grapefield.events;
+package com.example.grapefield.events.repository;
 
 import com.example.grapefield.events.model.entity.EventsImg;
 import org.springframework.data.jpa.repository.JpaRepository;

--- a/src/main/java/com/example/grapefield/events/repository/EventsRepository.java
+++ b/src/main/java/com/example/grapefield/events/repository/EventsRepository.java
@@ -1,4 +1,4 @@
-package com.example.grapefield.events;
+package com.example.grapefield.events.repository;
 
 import com.example.grapefield.events.model.entity.EventCategory;
 import com.example.grapefield.events.model.entity.Events;

--- a/src/main/java/com/example/grapefield/events/review/ReviewController.java
+++ b/src/main/java/com/example/grapefield/events/review/ReviewController.java
@@ -1,0 +1,4 @@
+package com.example.grapefield.events.review;
+
+public class ReviewController {
+}

--- a/src/main/java/com/example/grapefield/events/review/ReviewController.java
+++ b/src/main/java/com/example/grapefield/events/review/ReviewController.java
@@ -1,4 +1,62 @@
 package com.example.grapefield.events.review;
 
+import com.example.grapefield.base.ApiErrorResponses;
+import com.example.grapefield.base.ApiSuccessResponses;
+import com.example.grapefield.common.PageResponse;
+import com.example.grapefield.events.post.model.request.CommentRegisterReq;
+import com.example.grapefield.events.post.model.response.CommentListResp;
+import com.example.grapefield.events.review.model.request.ReviewRegisterReq;
+import com.example.grapefield.events.review.model.response.ReviewListResp;
+import com.example.grapefield.user.CustomUserDetails;
+import com.example.grapefield.user.model.entity.User;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.web.PageableDefault;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+
+@RequiredArgsConstructor
+@RestController
+@RequestMapping("/review")
 public class ReviewController {
+  private final ReviewService reviewService;
+  //TODO : 한줄평 등록, 코멘트 없이 별점만 남기는 것도 가능
+  @Operation(summary="한줄평 등록", description = "공연/전시 상세 페이지에서 한줄평을 등록")
+  @ApiResponses(
+      @ApiResponse(responseCode = "200", description = "등록 성공",
+          content = @Content(mediaType = "text/plain",
+              examples = @ExampleObject(value = "성공적으로 등록"))))
+  @ApiErrorResponses
+  @PostMapping("/register")
+  public ResponseEntity<Long> registerReview(
+      @RequestBody ReviewRegisterReq request, @AuthenticationPrincipal CustomUserDetails principal) {
+    if (principal == null) { return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body(null); }
+    Long reviewIdx = reviewService.registerReview(request, principal.getUser());
+    return ResponseEntity.ok(reviewIdx);
+  }
+
+  //TODO : 한줄평 목록 가져오기
+  @Operation(summary = "한줄평 조회", description = "공연/행사에 달린 모든 한줄평을 내용과 함께 조회")
+  @ApiSuccessResponses
+  @ApiErrorResponses
+  @GetMapping("/{idx}")
+  public ResponseEntity<PageResponse<ReviewListResp>> getReviewList(@PathVariable Long idx, @PageableDefault(size = 10, sort = "createdAt", direction = Sort.Direction.DESC) Pageable pageable, @AuthenticationPrincipal CustomUserDetails principal) {
+    User user = (principal != null) ? principal.getUser() : null;
+    Page<ReviewListResp> reviewPage = reviewService.getReviewList(idx, pageable, user);
+    PageResponse<ReviewListResp> response = PageResponse.from(reviewPage, reviewPage.getContent());
+    return ResponseEntity.ok(response);
+  }
+
+  //TODO:한줄평 삭제(실제로는 isVisible 을 false로 변환하는걸로 수정)
+  
+  //TODO: 한줄평 수정
 }

--- a/src/main/java/com/example/grapefield/events/review/ReviewService.java
+++ b/src/main/java/com/example/grapefield/events/review/ReviewService.java
@@ -1,0 +1,42 @@
+package com.example.grapefield.events.review;
+
+import com.example.grapefield.events.model.entity.Events;
+import com.example.grapefield.events.repository.EventsRepository;
+import com.example.grapefield.events.review.model.entity.Review;
+import com.example.grapefield.events.review.model.request.ReviewRegisterReq;
+import com.example.grapefield.events.review.model.response.ReviewListResp;
+import com.example.grapefield.events.review.repository.ReviewRepository;
+import com.example.grapefield.user.model.entity.User;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+
+import java.time.LocalDateTime;
+
+@Service
+@RequiredArgsConstructor
+public class ReviewService {
+  private final ReviewRepository reviewRepository;
+  private final EventsRepository eventsRepository;
+
+  public Long registerReview(ReviewRegisterReq request, User user) {
+    Events events = eventsRepository.findById(request.getEventIdx()).orElseThrow(()->new IllegalArgumentException("존재하지 않는 행사입니다."));
+    //한줄평 저장
+    Review review = Review.builder()
+        .user(user)
+        .events(events)
+        .content(request.getContent())
+        .rating(request.getRating())
+        .createdAt(LocalDateTime.now())
+        .updatedAt(LocalDateTime.now())
+        .build();
+    Review saveReview = reviewRepository.save(review);
+    return saveReview.getIdx();
+  }
+
+  public Page<ReviewListResp> getReviewList(Long idx, Pageable pageable, User user) {
+    return reviewRepository.findReviewList(idx, pageable, user);
+    //TODO : 특정 점수만 가져오는 기능 추가 필요
+  }
+}

--- a/src/main/java/com/example/grapefield/events/review/model/entity/Review.java
+++ b/src/main/java/com/example/grapefield/events/review/model/entity/Review.java
@@ -1,5 +1,6 @@
-package com.example.grapefield.events.model.entity;
+package com.example.grapefield.events.review.model.entity;
 
+import com.example.grapefield.events.model.entity.Events;
 import com.example.grapefield.user.model.entity.User;
 import jakarta.persistence.*;
 import lombok.AllArgsConstructor;

--- a/src/main/java/com/example/grapefield/events/review/model/request/ReviewRegisterReq.java
+++ b/src/main/java/com/example/grapefield/events/review/model/request/ReviewRegisterReq.java
@@ -1,0 +1,20 @@
+package com.example.grapefield.events.review.model.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@AllArgsConstructor
+@NoArgsConstructor
+@Getter
+@Schema(description="한줄평 등록 body")
+public class ReviewRegisterReq {
+  @Schema(description="이벤트 idx")
+  private Long eventIdx;
+  @Schema(description="(선택)한줄평", example = "배우의 연기가 멋있었어요.")
+  private String content;
+  @Schema(description="별점")
+  private Long rating;
+}

--- a/src/main/java/com/example/grapefield/events/review/model/response/ReviewListResp.java
+++ b/src/main/java/com/example/grapefield/events/review/model/response/ReviewListResp.java
@@ -1,4 +1,4 @@
-package com.example.grapefield.events.post.model.response;
+package com.example.grapefield.events.review.model.response;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.AllArgsConstructor;
@@ -10,20 +10,20 @@ import java.time.LocalDateTime;
 @AllArgsConstructor
 @NoArgsConstructor
 @Getter
-@Schema(description="게시글 상세 페이지에서 댓글 목록 및 내용 응답")
-public class CommentListResp {
+@Schema(description="이벤트 상세 페이지에서 한줄평 목록 및 내용 응답")
+public class ReviewListResp {
   @Schema(example = "1")
   private Long idx;
-  @Schema(description = "댓글 신고를 위해 유저 정보가 필요할 때 사용")
+  @Schema(description = "한줄평 신고를 위해 유저 정보가 필요할 때 사용")
   private Long user_idx;
   @Schema(description="작성자", example = "이독자")
   private String writer;
-  @Schema(description="댓글", example = "저도 무척이나 재밌게 보고 왔는데 공감되네요.")
+  @Schema(description="평점", example = "4")
+  private Long rating;
+  @Schema(description="한줄평 내용", example = "저도 무척이나 재밌게 보고 왔는데 공감되네요.")
   private String content;
-  @Schema(description="댓글 등록일",  example = "2025-01-09T00:00:00")
+  @Schema(description="한줄평 등록일",  example = "2025-01-09T00:00:00")
   private LocalDateTime createdAt;
-  @Schema(description="이 댓글이 수정된 것인지 여부", example = "true")
-  private boolean edited;
   @Schema(description="현재 로그인한 유저가 작성자이거나 ADMIN일 경우 수정/삭제 가능하도록 프론트에 반환하기 위한 값", example = "false")
   private boolean editable;
 }

--- a/src/main/java/com/example/grapefield/events/review/repository/ReviewCustomRepository.java
+++ b/src/main/java/com/example/grapefield/events/review/repository/ReviewCustomRepository.java
@@ -1,0 +1,10 @@
+package com.example.grapefield.events.review.repository;
+
+import com.example.grapefield.events.review.model.response.ReviewListResp;
+import com.example.grapefield.user.model.entity.User;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+
+public interface ReviewCustomRepository {
+  Page<ReviewListResp> findReviewList(Long idx, Pageable pageable, User user);
+}

--- a/src/main/java/com/example/grapefield/events/review/repository/ReviewCustomRepositoryImpl.java
+++ b/src/main/java/com/example/grapefield/events/review/repository/ReviewCustomRepositoryImpl.java
@@ -1,0 +1,54 @@
+package com.example.grapefield.events.review.repository;
+
+import com.example.grapefield.events.model.entity.QEvents;
+import com.example.grapefield.events.review.model.entity.QReview;
+import com.example.grapefield.events.review.model.response.ReviewListResp;
+import com.example.grapefield.user.model.entity.QUser;
+import com.example.grapefield.user.model.entity.User;
+import com.querydsl.core.types.Projections;
+import com.querydsl.core.types.dsl.Expressions;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+@Repository
+@RequiredArgsConstructor
+public class ReviewCustomRepositoryImpl implements ReviewCustomRepository{
+  private final JPAQueryFactory queryFactory;
+
+  @Override
+  public Page<ReviewListResp> findReviewList(Long idx, Pageable pageable, User user) {
+    QReview qReview = QReview.review;
+    QUser qUser = QUser.user;
+    QEvents qEvents =  QEvents.events;
+
+    List<ReviewListResp> reviews = queryFactory
+        .select(Projections.constructor(ReviewListResp.class,
+            qReview.idx, qReview.user.idx, qUser.username, qReview.rating, qReview.content, qReview.createdAt,
+            user == null
+                ? Expressions.constant(false)
+                : Expressions.booleanTemplate(
+                "({0} = {1}) or ({2} = 'ROLE_ADMIN')",
+                qReview.user.idx,
+                user.getIdx(),
+                user.getRole().name()
+            )
+        ))
+        .from(qReview)
+        .join(qReview.user, qUser)
+        .join(qReview.events, qEvents)
+        .where(qEvents.idx.eq(idx))
+        .offset(pageable.getOffset())
+        .limit(pageable.getPageSize())
+        .orderBy(qReview.createdAt.desc())
+        .fetch();
+
+    Long total = queryFactory.select(qReview.count()).from(qReview).join(qReview.events, qEvents).where(qEvents.idx.eq(idx)).fetchOne();
+    return new PageImpl<>(reviews, pageable, total != null?total:0);
+  }
+}

--- a/src/main/java/com/example/grapefield/events/review/repository/ReviewRepository.java
+++ b/src/main/java/com/example/grapefield/events/review/repository/ReviewRepository.java
@@ -1,0 +1,7 @@
+package com.example.grapefield.events.review.repository;
+
+import com.example.grapefield.events.review.model.entity.Review;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ReviewRepository extends JpaRepository<Review,Long>, ReviewCustomRepository{
+}

--- a/src/main/java/com/example/grapefield/user/model/entity/User.java
+++ b/src/main/java/com/example/grapefield/user/model/entity/User.java
@@ -2,7 +2,7 @@ package com.example.grapefield.user.model.entity;
 
 import com.example.grapefield.chat.model.entity.ChatMessageCurrent;
 import com.example.grapefield.chat.model.entity.ChatroomMember;
-import com.example.grapefield.events.model.entity.Review;
+import com.example.grapefield.events.review.model.entity.Review;
 import com.example.grapefield.events.post.model.entity.Post;
 import com.example.grapefield.events.post.model.entity.PostComment;
 import com.example.grapefield.events.post.model.entity.PostRecommend;


### PR DESCRIPTION
## #️⃣ Issue Number

## 📝 요약(Summary)
게시판과 마찬가지로 채팅방도 새로운 공연/전시가 등록되면 해당 idx와 title을 받아서 방이 자동으로 추가되도록 수정

## 🛠️ PR 유형
어떤 변경 사항이 있나요?
- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [x] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [x] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## 📸스크린샷 (선택)

## 💬 공유사항 to 리뷰어

<!--- 리뷰어가 중점적으로 봐줬으면 좋겠는 부분이 있으면 적어주세요. -->
<!--- 논의해야할 부분이 있다면 적어주세요.-->
<!--- ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요? -->

## ✅ PR Checklist

PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [ ] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).