### PR TITLE
[feat] 파드개수만큼 메세지 중복 저장 해결

### DIFF
--- a/src/main/java/com/example/grapefield/chat/controller/ChatRoomDetailController.java
+++ b/src/main/java/com/example/grapefield/chat/controller/ChatRoomDetailController.java
@@ -32,10 +32,6 @@ public class ChatRoomDetailController {
     @Operation(summary = "특정 채팅방 메시지 조회", description = "채팅방 Idx를 통해 특정 채팅방의 채팅 내용 확인")
     public ChatRoomDetailResp chatRoomDetail(@PathVariable("roomIdx") Long roomIdx,
                                              @AuthenticationPrincipal CustomUserDetails userDetails) {
-
-        Long userIdx =  userDetails.getUser().getIdx();
-        chatRoomMemberService.joinRoom(userIdx, roomIdx);
-
         ChatRoom room = chatRoomService.findByIdx(roomIdx);
         return ChatRoomDetailResp.builder()
                 .roomIdx(roomIdx)

--- a/src/main/java/com/example/grapefield/chat/controller/ChatWebSocketController.java
+++ b/src/main/java/com/example/grapefield/chat/controller/ChatWebSocketController.java
@@ -57,8 +57,11 @@ public class ChatWebSocketController {
                 chatMessageReq.getRoomIdx(), chatMessageReq.getContent(), user.getIdx());
 
         ChatMessageKafkaReq chatMessageKafkaReq =
-                new ChatMessageKafkaReq(chatMessageReq.getRoomIdx(), user.getIdx(), chatMessageReq.getContent());
-
+                ChatMessageKafkaReq.builder()
+                        .roomIdx(chatMessageReq.getRoomIdx())
+                        .sendUserIdx(user.getIdx())
+                        .content(chatMessageReq.getContent()).build();
+        log.debug("웹소켓 컨트롤러 sendMessage 메소드 chatMessageKafkaReq={}", chatMessageReq.toString());
         chatKafkaProducer.sendMessage(chatMessageKafkaReq);//  클라이언트로부터의 메시지를 kafka로 전송
     }
 

--- a/src/main/java/com/example/grapefield/chat/model/entity/ChatMessageCurrent.java
+++ b/src/main/java/com/example/grapefield/chat/model/entity/ChatMessageCurrent.java
@@ -14,16 +14,20 @@ import java.time.LocalDateTime;
 @AllArgsConstructor
 @NoArgsConstructor
 @Getter
+@Table(name = "chat_message_current", uniqueConstraints = @UniqueConstraint(columnNames = "message_uuid"))
 public class ChatMessageCurrent {
     @Id
     private Long messageIdx;
+
+    @Column(name = "message_uuid", nullable = false, unique = true)
+    private String messageUuid; // JPA 유니크 제약 설정
 
     @MapsId
     @OneToOne
     @JoinColumn(name = "message_idx")
     private ChatMessageBase base;
 
-    @ManyToOne
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
     @JoinColumn(name = "room_idx")
     private ChatRoom chatRoom;
 
@@ -31,6 +35,7 @@ public class ChatMessageCurrent {
     @JoinColumn(name = "user_idx")
     private User user;
 
+    @Column(columnDefinition = "TEXT", nullable = false)
     private String content;
     private LocalDateTime createdAt;
 

--- a/src/main/java/com/example/grapefield/chat/model/entity/ProcessedMessage.java
+++ b/src/main/java/com/example/grapefield/chat/model/entity/ProcessedMessage.java
@@ -1,0 +1,21 @@
+package com.example.grapefield.chat.model.entity;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+@Getter
+public class ProcessedMessage {
+    @Id
+    private String messageUuid;
+    private LocalDateTime processedAt;
+}

--- a/src/main/java/com/example/grapefield/chat/model/request/ChatMessageKafkaReq.java
+++ b/src/main/java/com/example/grapefield/chat/model/request/ChatMessageKafkaReq.java
@@ -6,6 +6,8 @@ import com.example.grapefield.user.model.entity.User;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.*;
 
+import java.util.UUID;
+
 @Getter
 @Setter
 @AllArgsConstructor
@@ -13,6 +15,9 @@ import lombok.*;
 @Builder
 @Schema(description = "Kafka 전송용 채팅 메시지 DTO")
 public class ChatMessageKafkaReq {
+    @Schema(description = "메세지 고유 ID(uuid)", example="550k8400-j12w-47d4-anct-199802190000", required = true)
+    @Builder.Default
+    private String messageUuid = UUID.randomUUID().toString();
     @Schema(description = "채팅방 ID", example = "1", required = true)
     private Long roomIdx;
     @Schema(description = "보낸 사용자 ID", example = "3", required = true)
@@ -22,6 +27,7 @@ public class ChatMessageKafkaReq {
 
     public ChatMessageCurrent toEntity(ChatMessageBase base, ChatRoom room, User user) {
         return ChatMessageCurrent.builder()
+                .messageUuid(this.messageUuid)
                 .base(base)
                 .chatRoom(room)
                 .user(user)

--- a/src/main/java/com/example/grapefield/chat/model/request/ChatMessageReq.java
+++ b/src/main/java/com/example/grapefield/chat/model/request/ChatMessageReq.java
@@ -4,9 +4,11 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import lombok.Getter;
+import lombok.ToString;
 
 @Getter
 @Schema(description = "채팅 메시지 전송 요청")
+@ToString
 public class ChatMessageReq {
 
     @Schema(description = "채팅방 ID", example = "1", required = true)

--- a/src/main/java/com/example/grapefield/chat/repository/ProcessedMessageRepository.java
+++ b/src/main/java/com/example/grapefield/chat/repository/ProcessedMessageRepository.java
@@ -1,0 +1,7 @@
+package com.example.grapefield.chat.repository;
+
+import com.example.grapefield.chat.model.entity.ProcessedMessage;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ProcessedMessageRepository extends JpaRepository<ProcessedMessage, String> {
+}


### PR DESCRIPTION
## #️⃣ Issue Number
#166

## 📝 요약(Summary)
Idempotent 패턴 적용하여 ChatMessageKafkaReq에 UUID생성 추가, ChatMessageCurrent에 UUID 저장하기

## 🛠️ PR 유형
어떤 변경 사항이 있나요?
- [ ] 새로운 기능 추가
- [x] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [x] 코드 리팩토링
- [x] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## 📸스크린샷 (선택)

## 💬 공유사항 to 리뷰어

<!--- 리뷰어가 중점적으로 봐줬으면 좋겠는 부분이 있으면 적어주세요. -->
<!--- 논의해야할 부분이 있다면 적어주세요.-->
<!--- ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요? -->

## ✅ PR Checklist

PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).