### PR TITLE
[feat/chat/redis] 하트기능 Redis 도입, Idempotent pattern 적용

### DIFF
--- a/src/main/java/com/example/grapefield/chat/config/KafkaConfig.java
+++ b/src/main/java/com/example/grapefield/chat/config/KafkaConfig.java
@@ -5,17 +5,19 @@ import com.example.grapefield.chat.model.request.ChatMessageKafkaReq;
 import com.example.grapefield.chat.model.response.ChatMessageResp;
 import com.example.grapefield.chat.model.response.ChatParticipantEventResp;
 import com.example.grapefield.chat.model.response.UserChatListEventResp;
+import org.apache.kafka.clients.producer.ProducerConfig;
 import org.apache.kafka.common.serialization.StringDeserializer;
 import org.apache.kafka.clients.consumer.ConsumerConfig;
+import org.apache.kafka.common.serialization.StringSerializer;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.kafka.annotation.EnableKafka;
 import org.springframework.kafka.config.ConcurrentKafkaListenerContainerFactory;
-import org.springframework.kafka.core.ConsumerFactory;
-import org.springframework.kafka.core.DefaultKafkaConsumerFactory;
+import org.springframework.kafka.core.*;
 import org.springframework.kafka.support.serializer.ErrorHandlingDeserializer;
 import org.springframework.kafka.support.serializer.JsonDeserializer;
+import org.springframework.kafka.support.serializer.JsonSerializer;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -25,6 +27,36 @@ import java.util.Map;
 public class KafkaConfig {
     @Value("${spring.kafka.bootstrap-servers}")
     private String bootstrapServers;
+
+    // 브로드캐스트용 group-id (ConfigMap으로 인스턴스별 분리)
+    @Value("${spring.kafka.consumer.chat.group-id}")
+    private String chatGroupId;
+    @Value("${spring.kafka.consumer.heart.group-id}")
+    private String heartGroupId;
+    @Value("${spring.kafka.consumer.highlight.group-id}")
+    private String highlightGroupId;
+
+    // ProducerFactory & KafkaTemplate
+    @Bean
+    public ProducerFactory<String, Object> producerFactory() {
+        Map<String, Object> props = new HashMap<>();
+        props.put(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, bootstrapServers);
+        props.put(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, StringSerializer.class);
+        props.put(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, JsonSerializer.class);
+        props.put(ProducerConfig.ACKS_CONFIG, "all");
+        props.put(ProducerConfig.RETRIES_CONFIG, 5);
+        props.put(ProducerConfig.BATCH_SIZE_CONFIG, 32_768);
+        props.put(ProducerConfig.MAX_IN_FLIGHT_REQUESTS_PER_CONNECTION, 1);
+        props.put(ProducerConfig.COMPRESSION_TYPE_CONFIG, "snappy");
+        return new DefaultKafkaProducerFactory<>(props);
+    }
+
+
+    @Bean
+    public KafkaTemplate<String, Object> kafkaTemplate() {
+        return new KafkaTemplate<>(producerFactory());
+    }
+
 
     @Bean
     public Map<String, Object> commonConsumerProps(@Value("${spring.kafka.bootstrap-servers}") String servers) {
@@ -45,7 +77,7 @@ public class KafkaConfig {
     public ConsumerFactory<String, ChatMessageKafkaReq> messageConsumerFactory() {
         Map<String, Object> props = new HashMap<>();
         props.put(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, bootstrapServers);
-        props.put(ConsumerConfig.GROUP_ID_CONFIG, "chat-group");
+        props.put(ConsumerConfig.GROUP_ID_CONFIG, chatGroupId);
         props.put(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class);
         props.put(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, JsonDeserializer.class);
 
@@ -75,7 +107,7 @@ public class KafkaConfig {
     public ConsumerFactory<String, ChatHeartKafkaReq> heartConsumerFactory() {
         Map<String, Object> props = new HashMap<>();
         props.put(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, bootstrapServers);
-        props.put(ConsumerConfig.GROUP_ID_CONFIG, "chat-like-group");
+        props.put(ConsumerConfig.GROUP_ID_CONFIG, heartGroupId);
         props.put(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class);
         props.put(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, JsonDeserializer.class);
 
@@ -106,7 +138,7 @@ public class KafkaConfig {
     public ConsumerFactory<String, ChatMessageKafkaReq> highlightConsumerFactory() {
         Map<String, Object> props = new HashMap<>();
         props.put(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, bootstrapServers);
-        props.put(ConsumerConfig.GROUP_ID_CONFIG, "chat-highlight-group"); // 💡 그룹 다르게
+        props.put(ConsumerConfig.GROUP_ID_CONFIG, highlightGroupId); // 💡 그룹 다르게
         props.put(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class);
         props.put(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, JsonDeserializer.class);
 

--- a/src/main/java/com/example/grapefield/chat/controller/ChatWebSocketController.java
+++ b/src/main/java/com/example/grapefield/chat/controller/ChatWebSocketController.java
@@ -68,12 +68,13 @@ public class ChatWebSocketController {
     @Operation(summary = "채팅방 하트 전송", description = "클라이언트에서 전송한 하트(좋아요) 이벤트를 Kafka로 전달")
     public void likeRoom(@DestinationVariable Long roomIdx,
                          @Payload ChatHeartKafkaReq heartReq,
+                         /*@Payload ChatHeartKafkaReq heartReq,*/
                          Principal principal) {
         CustomUserDetails userDetails = (CustomUserDetails) ((Authentication) principal).getPrincipal();
         Long userIdx = userDetails.getUser().getIdx();
-        log.info("WebSocket ❤️ 하트 수신: roomIdx={}, userIdx={}", roomIdx, userIdx);
+        log.info("WebSocket ❤️ 하트 수신: roomIdx={}, userIdx={}", roomIdx, heartReq /* userIdx */);
         chatKafkaProducer.likeRoom(heartReq);
-}
+    }
 
 
     //Swagger 노출용으로, 실제로는 아무 기능이 없는 빈 메소드

--- a/src/main/java/com/example/grapefield/chat/kafka/ChatKafkaProducer.java
+++ b/src/main/java/com/example/grapefield/chat/kafka/ChatKafkaProducer.java
@@ -28,7 +28,5 @@ public class ChatKafkaProducer {
         String topic = "chat-like-" + chatHeartKafkaReq.getRoomIdx();
         log.info("✅ KafkaProducer 발행: send heart ♥️ message'{}' to topic'{}'", chatHeartKafkaReq, topic);
         kafkaTemplate.send(topic, chatHeartKafkaReq);
-        // ⭐⭐백엔드 파드 부하분산 처리 하기 전 중복 변경을 막기 위해 임시로 컨슈머에서 프로듀서로 보냄⭐⭐
-        chatRoomService.increaseHeartCount(chatHeartKafkaReq.getRoomIdx());
     }
 }

--- a/src/main/java/com/example/grapefield/chat/kafka/ChatKafkaProducer.java
+++ b/src/main/java/com/example/grapefield/chat/kafka/ChatKafkaProducer.java
@@ -5,8 +5,12 @@ import com.example.grapefield.chat.model.request.ChatMessageKafkaReq;
 import com.example.grapefield.chat.service.ChatRoomService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.apache.kafka.clients.producer.RecordMetadata;
 import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.kafka.support.SendResult;
 import org.springframework.stereotype.Component;
+
+import java.util.concurrent.CompletableFuture;
 
 @Slf4j
 @Component
@@ -25,8 +29,9 @@ public class ChatKafkaProducer {
 
     public void likeRoom(ChatHeartKafkaReq chatHeartKafkaReq) {
         // kafkaTopicService.createHeartKafkaTopicIfNotExist(chatHeartKafkaReq);
-        String topic = "chat-like-" + chatHeartKafkaReq.getRoomIdx();
-        log.info("✅ KafkaProducer 발행: send heart ♥️ message'{}' to topic'{}'", chatHeartKafkaReq, topic);
+        String topic = "chat-like-" + chatHeartKafkaReq.getRoomIdx(); /*chatHeartKafkaReq.getRoomIdx();*/
+        log.info("✅ KafkaProducer 발행: send heart ♥️{}'", topic);
         kafkaTemplate.send(topic, chatHeartKafkaReq);
+
     }
 }

--- a/src/main/java/com/example/grapefield/chat/kafka/HeartKafkaConsumer.java
+++ b/src/main/java/com/example/grapefield/chat/kafka/HeartKafkaConsumer.java
@@ -30,14 +30,22 @@ public class HeartKafkaConsumer {
     )
     public void consumeHeart(ChatHeartKafkaReq chatHeartKafkaReq) {
         Long roomIdx = chatHeartKafkaReq.getRoomIdx();
-        log.info("✅ KafkaConsumer 좋아요 ♥\uFE0F 하트 수신: roomIdx={}", roomIdx);
-        ChatRoom chatRoom = chatRoomRepository.findById(roomIdx).orElse(null);
-        chatRoomService.increaseHeartDb(roomIdx);
-        Long newCount =
-                chatRoomService.increaseHeartRedis(Objects.requireNonNull(chatRoom));
-
+        String heartIdx = chatHeartKafkaReq.getHeartIdx();
+        log.info("✅ KafkaConsumer 좋아요 ♥\uFE0F 하트 수신: roomIdx={}, heartIdx={}", roomIdx, heartIdx);
+        // 기존에 없는 경우 추가 되지 않기 때문에 때문에 added에 0을 반환한다.
+        Long added = redisTemplate.opsForSet().add("processed:hearts", heartIdx);
+        Long newCount;
+        if(added != null && added > 0) {
+            newCount=chatRoomService.increaseHeart(roomIdx);
+        } else {
+            log.info("이미 처리된 요청이므로 취소");
+            String redisKey = "chat:"+roomIdx+":likes";
+            newCount = Long.parseLong((redisTemplate.opsForValue().get(redisKey)).toString());
+        }
         // 2. WebSocket 브로커로 브로드캐스트 (프론트에서 애니메이션 띄우게)
         HeartResp resp = new HeartResp(roomIdx, newCount);
+        // // Redis 없는 환경에서는 다음으로 바꾸면 된다.⤵️⤵️
+        // HeartResp resp = new HeartResp(roomIdx, chatRoom.getHeartCnt());
         messagingTemplate.convertAndSend("/topic/chat.room.likes." + roomIdx, resp);
         log.info("✅ 📡 WebSocket Broadcast 좋아요 ♥\uFE0F 하트 -> roomIdx={}", roomIdx);
     }

--- a/src/main/java/com/example/grapefield/chat/model/request/ChatHeartKafkaReq.java
+++ b/src/main/java/com/example/grapefield/chat/model/request/ChatHeartKafkaReq.java
@@ -16,6 +16,7 @@ import lombok.NoArgsConstructor;
 @Builder
 @Schema(description = "카프카 하트 전송용")
 public class ChatHeartKafkaReq {
+    private String heartIdx;
     @NotNull
     @Schema(description = "채팅방 ID", example = "1", required = true)
     private Long roomIdx;

--- a/src/main/java/com/example/grapefield/chat/service/ChatRoomService.java
+++ b/src/main/java/com/example/grapefield/chat/service/ChatRoomService.java
@@ -42,14 +42,41 @@ public class ChatRoomService {
         return chatMessageCurrentRepository.findByChatRoom_IdxOrderByCreatedAtDesc(roomIdx, pageable);
     }
 
-
     @Transactional
-    public void increaseHeartDb(Long roomIdx) {
+    public Long increaseHeart(Long roomIdx) {
         // DB 갱신
         ChatRoom chatRoom = chatRoomRepository.findById(roomIdx)
                 .orElseThrow(() -> new IllegalArgumentException("채팅방 없음. roomIdx=" + roomIdx));
-        chatRoom.increaseHeart(); // heartCnt += 1
-        log.info("✅[DataBase] ChatRoom({}) ♥️하트 개수 갱신 heartCnt", roomIdx);
+
+        String redisKey = "chat:"+roomIdx+":likes";
+        Object rawValue = redisTemplate.opsForValue().get(redisKey);
+
+        Long newCount;
+        if (rawValue == null) {
+            newCount = null;
+            log.info("🌟rawValue==null 일 때 newCount: {}", newCount);
+        }
+        else {
+            newCount = Long.parseLong((redisTemplate.opsForValue().get(redisKey)).toString());
+            log.info("🌟rawValue!=null 일 때 newCount: {}", newCount);
+        }
+        if (!Objects.equals(newCount, chatRoom.getHeartCnt()) || newCount == null){
+            chatRoom.increaseHeart(); // heartCnt += 1
+            log.info("✅[DataBase] ChatRoom({}) ♥️하트 개수 갱신 heartCnt:{}", roomIdx, chatRoom.getHeartCnt());
+            redisTemplate.opsForValue().set(redisKey, chatRoom.getHeartCnt());
+            // newCount = chatRoom.getHeartCnt();
+            newCount = Long.parseLong((redisTemplate.opsForValue().get(redisKey)).toString());
+            log.info("⭐redisTemplate.opsForValue().set(redisKey, chatRoom.getHeartCnt()); chatRoom.getHearCnt() = " + chatRoom.getHeartCnt());
+            log.info("⭐redisTemplate.opsForValue().set(redisKey, chatRoom.getHeartCnt()); newCount"+ newCount);
+            log.info("✅[Redis] chat:{}:likes ♥️하트 개수 갱신 heartCnt:{}", roomIdx,newCount);
+        } else {
+            chatRoom.increaseHeart(); // heartCnt += 1
+            log.info("✅[DataBase] ChatRoom({}) ♥️하트 개수 갱신 heartCnt:{}", roomIdx, chatRoom.getHeartCnt());
+            newCount = redisTemplate.opsForValue().increment(redisKey);
+            log.info("✅[Redis] chat:{}:likes ♥️하트 개수 갱신 heartCnt:{}", roomIdx,newCount);
+        }
+        return newCount;
+
     }
 
     @Transactional
@@ -57,11 +84,8 @@ public class ChatRoomService {
         Long roomIdx = chatRoom.getIdx();
         String redisKey = "chat:"+roomIdx+":likes";
         Long newCount = redisTemplate.opsForValue().increment(redisKey);
-
-        if (!Objects.equals(newCount, chatRoom.getHeartCnt()) || newCount == null){
-            newCount = chatRoom.getHeartCnt();
-            newCount++;
-        }
+        log.info("⭐Long newCount = redisTemplate.opsForValue().increment(redisKey); 후 chatRoom.getHearCnt() = " + chatRoom.getHeartCnt());
+        log.info("⭐Long newCount = redisTemplate.opsForValue().increment(redisKey); 후 newCount = " + newCount);
 
         return newCount;
 

--- a/src/main/java/com/example/grapefield/chat/service/ChatRoomService.java
+++ b/src/main/java/com/example/grapefield/chat/service/ChatRoomService.java
@@ -47,16 +47,25 @@ public class ChatRoomService {
         // DB 갱신
         ChatRoom chatRoom = chatRoomRepository.findById(roomIdx)
                 .orElseThrow(() -> new IllegalArgumentException("채팅방 없음. roomIdx=" + roomIdx));
+        log.info("♥️하트 개수 갱신 전!! 🌟chatRoom.getHeartCnt:"+chatRoom.getHeartCnt());
         chatRoom.increaseHeart(); // heartCnt += 1
         log.info("✅[DataBase] ChatRoom({}) ♥️하트 개수 갱신 heartCnt updated: {}", roomIdx, chatRoom.getHeartCnt());
-
+        log.info("♥️하트 개수 갱신 후!! 🌟chatRoom.getHeartCnt:"+chatRoom.getHeartCnt());
         // Redis 캐시에 동기화
+        log.info("🌟🌟🌟🌟🌟🌟 Redis 코드 시작... ");
         String redisKey = "chat:"+roomIdx+":likes";
+        log.info("🌟호출 당시 redisKey:"+redisKey);
         Long newCount = redisTemplate.opsForValue().increment(redisKey);
+        log.info("🌟호출 당시 redisKey:"+redisKey);
+        log.info("🌟호출 당시 newCount:"+newCount);
         if (newCount == null) {
+            log.info("🌟newCount = null");
             //키가 없을 경우 DB의 값으로 초기값 세팅
             redisTemplate.opsForValue().set(redisKey, chatRoom.getHeartCnt());
+            log.info("🌟null일 때 chatRoom.getHeartCnt()로 set 하고 나서 redisKey:"+redisKey);
+            log.info("🌟chatRoom.getHeartCnt:"+chatRoom.getHeartCnt());
             newCount = chatRoom.getHeartCnt();
+            log.info("🌟null일 때 chatRoom.getHeartCnt()로 할당하고 나서 newCount:"+newCount);
         }
         log.info("✅[Redis] ChatRoom({}) ♥️하트 개수 갱신 heartCnt updated: {}", roomIdx, newCount);
     }


### PR DESCRIPTION
## #️⃣ Issue Number
#182

## 📝 요약(Summary)
- HeartKafkaConsumer.java ChatRoomService.java 채팅방마다 하트(좋아요) 소비시 Redis에도 함께 저장
- HeartResponse DTO 생성, `ChatWebSocketController.java`에서  Redis에서 하트 수를 DTO에 저장하여 실시간 제공
- payload에 프론트에서 생성한 uuid를 받아와서 idempotent pattern 적용 (k8s 환경에서 백엔드 POD 부하분산 환경 적응)

## 🛠️ PR 유형
어떤 변경 사항이 있나요?
- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [x] 코드 리팩토링
- [x] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## 📸스크린샷 (선택)

## 💬 공유사항 to 리뷰어

<!--- 리뷰어가 중점적으로 봐줬으면 좋겠는 부분이 있으면 적어주세요. -->
<!--- 논의해야할 부분이 있다면 적어주세요.-->
<!--- ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요? -->

## ✅ PR Checklist

PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).